### PR TITLE
Update ABOS reporting queries

### DIFF
--- a/report/SQL_reporting_queries/anmn.sql
+++ b/report/SQL_reporting_queries/anmn.sql
@@ -36,7 +36,7 @@ CREATE or replace VIEW anmn_all_deployments_view AS
 	(m.time_deployment_end - m.time_deployment_start) AS deployment_duration,
 	GREATEST('00:00:00'::interval, (LEAST(m.time_deployment_end, m.time_coverage_end) - GREATEST(m.time_deployment_start, m.time_coverage_start))) AS good_data_duration
       FROM anmn_metadata.indexed_file i JOIN anmn_metadata.file_metadata m ON m.file_id = i.id
-      WHERE NOT m.realtime AND NOT m.deleted
+      WHERE i.url LIKE 'IMOS/ANMN%' AND NOT m.realtime AND NOT m.deleted
     )
 
   SELECT 

--- a/report/SQL_reporting_queries/anmn_rt.sql
+++ b/report/SQL_reporting_queries/anmn_rt.sql
@@ -30,8 +30,9 @@ CREATE or replace VIEW anmn_rt_all_deployments_view AS
          ELSE site_code
     END AS platform_code,
     COALESCE(instrument_nominal_depth::numeric, geospatial_vertical_max::numeric) AS sensor_depth
-  FROM anmn_metadata.file_metadata m LEFT JOIN site_view s USING (site_code)
-  WHERE realtime AND NOT deleted AND time_coverage_start > '2000-01-01'
+  FROM anmn_metadata.indexed_file i JOIN anmn_metadata.file_metadata m ON m.file_id = i.id
+                                    LEFT JOIN site_view s USING (site_code)
+  WHERE i.url LIKE 'IMOS/ANMN%' AND m.realtime AND NOT m.deleted AND m.time_coverage_start > '2000-01-01'
   ORDER BY site_name, channel_id, start_date;
 
 grant all on table anmn_rt_all_deployments_view to public;


### PR DESCRIPTION
All ABOS files are now being indexed into the generic `anmn_metadata` harvester (apologies for the confusing name). This replaces the old ABOS reporting harvester, so this PR updates the reporting views to make use of that schema.

Also,
- Remove unused fields from abos.sql (days_to_*, author, principal_investigator).
- Update ANMN queries to explicitly select ANMN files.
