### PR TITLE
DO NOT MERGE: Support new sattag qc reporting

### DIFF
--- a/report/SQL_reporting_queries/aatams_sattag_qc.sql
+++ b/report/SQL_reporting_queries/aatams_sattag_qc.sql
@@ -1,0 +1,156 @@
+﻿SET search_path = reporting,
+    public;
+
+
+DROP VIEW IF EXISTS aatams_sattag_qc_all_deployments_view CASCADE;
+
+
+CREATE or replace VIEW aatams_sattag_qc_all_deployments_view AS WITH qc AS
+  (SELECT device_id,
+          COUNT(*) AS nb_measurements,
+          min(pressure) AS min_pressure,
+          max(pressure) AS max_pressure
+   FROM aatams_sattag_qc_dm.aatams_sattag_qc_profile_data
+   GROUP BY device_id)
+SELECT 'Near real-time CTD data' AS data_type,
+       COALESCE(m.sattag_program|| ' - ' || m.state_country) AS headers,
+       m.sattag_program,
+       m.release_site,
+       m.state_country,
+       m.tag_type,
+       m.common_name AS species_name,
+       m.device_id AS tag_code,
+       COUNT(map.profile_id) AS nb_profiles,
+       SUM(map.nb_measurements) AS nb_measurements,
+       min(map."timestamp") AS coverage_start,
+       max(map."timestamp") AS coverage_end,
+       round((date_part('days', max(map."timestamp") - min(map."timestamp")) + (date_part('hours', max(map."timestamp") - min(map."timestamp")))/24)::numeric, 1) AS coverage_duration,
+       round(min(st_y(st_centroid(map.geom)))::numeric, 1) AS min_lat,
+       round(max(st_y(st_centroid(map.geom)))::numeric, 1) AS max_lat,
+       round(min(st_x(st_centroid(map.geom)))::numeric, 1) AS min_lon,
+       round(max(st_x(st_centroid(map.geom)))::numeric, 1) AS max_lon,
+       min(map.min_pressure) AS min_depth,
+       max(map.max_pressure) AS max_depth
+FROM aatams_sattag_qc_nrt.metadata m
+LEFT JOIN aatams_sattag_qc_nrt.aatams_sattag_qc_profile_map map ON m.device_id = map.device_id
+WHERE m.device_wmo_ref != ''
+GROUP BY m.sattag_program,
+         m.device_id,
+         m.tag_type,
+         m.common_name,
+         m.release_site
+HAVING COUNT(map.profile_id) != 0
+UNION ALL
+SELECT 'Delayed mode CTD data' AS data_type,
+       COALESCE(m.sattag_program|| ' - ' || m.state_country) AS headers,
+       m.sattag_program,
+       m.release_site,
+       m.state_country,
+       m.tag_type,
+       m.common_name AS species_name,
+       m.device_id AS tag_code,
+       COUNT(dmap.profile_id) AS nb_profiles,
+       SUM(dmap.nb_measurements) AS nb_measurements,
+       min(dmap."timestamp") AS coverage_start,
+       max(dmap."timestamp") AS coverage_end,
+       round((date_part('days', max(dmap."timestamp") - min(dmap."timestamp")) + (date_part('hours', max(dmap."timestamp") - min(dmap."timestamp")))/24)::numeric, 1) AS coverage_duration,
+       round(min(st_y(st_centroid(dmap.geom)))::numeric, 1) AS min_lat,
+       round(max(st_y(st_centroid(dmap.geom)))::numeric, 1) AS max_lat,
+       round(min(st_x(st_centroid(dmap.geom)))::numeric, 1) AS min_lon,
+       round(max(st_x(st_centroid(dmap.geom)))::numeric, 1) AS max_lon,
+       min(dmap.min_pressure) AS min_depth,
+       max(dmap.max_pressure) AS max_depth
+FROM aatams_sattag_qc_nrt.metadata m
+LEFT JOIN aatams_sattag_qc_dm.aatams_sattag_qc_profile_map dmap ON m.device_id = dmap.device_id
+GROUP BY m.sattag_program,
+         m.device_id,
+         m.tag_type,
+         m.common_name,
+         m.release_site
+HAVING COUNT(dmap.profile_id) != 0
+UNION ALL
+SELECT 'Delayed-mode QCd CTD data' AS data_type,
+       COALESCE(substring(qc_m.smru_platform_code, '^[^-]*')|| ' - ' || CASE
+                                                                            WHEN release_location IN ('Kerguelen', 'Dumont d''Urville') THEN 'French Overseas Territory'
+                                                                            WHEN release_location IN ('Campbell', 'Campbell Island') THEN 'New Zealand'
+                                                                            ELSE 'Australia Antarctic Territory'
+                                                                        END || ' - ' || pi_name) AS headers,
+       substring(qc_m.smru_platform_code, '^[^-]*') AS sattag_program,
+       CASE
+           WHEN release_location = 'Davies' THEN 'Davis'
+           WHEN release_location = 'Campbell' THEN 'Campbell Island'
+           ELSE release_location
+       END AS release_site,
+       CASE
+           WHEN release_location IN ('Kerguelen',
+                                     'Dumont d''Urville') THEN 'French Overseas Territory'
+           WHEN release_location IN ('Campbell',
+                                     'Campbell Island') THEN 'New Zealand'
+           ELSE 'Australia Antarctic Territory'
+       END AS state_country,
+       'SMRU CTD tag' AS tag_type,
+       CASE
+           WHEN species_name = 'Weddel seal' THEN 'Weddell seal'
+           WHEN species_name = 'Southern ellie' THEN 'Southern Elephant Seal'
+           ELSE species_name
+       END AS species_name,
+       qc_m.smru_platform_code AS tag_code,
+       COUNT(profile_no) AS nb_profiles,
+       qc.nb_measurements AS nb_measurements,
+       min(juld_location) AS coverage_start,
+       max(juld_location) AS coverage_end,
+       round((date_part('days', max(juld_location) - min(juld_location)) + (date_part('hours', max(juld_location) - min(juld_location)))/24)::numeric, 1) AS coverage_duration,
+       round(min(st_y(st_centroid(position)))::numeric, 1) AS min_lat,
+       round(max(st_y(st_centroid(position)))::numeric, 1) AS max_lat,
+       round(min(st_x(st_centroid(position)))::numeric, 1) AS min_lon,
+       round(max(st_x(st_centroid(position)))::numeric, 1) AS max_lon,
+       qc.min_pressure AS min_depth,
+       qc.max_pressure AS max_depth
+FROM aatams_sattag_qc_ctd.aatams_sattag_qc_ctd_profile_map qc_m
+JOIN qc ON qc.device_id = qc_m.smru_platform_code
+GROUP BY qc_m.smru_platform_code,
+         qc_m.pi_name,
+         qc_m.species_name,
+         qc_m.release_location,
+         qc.nb_measurements,
+         qc.min_pressure,
+         qc.max_pressure
+ORDER BY data_type,
+         sattag_program,
+         species_name,
+         tag_code;
+
+-- Data summary view
+
+CREATE OR REPLACE VIEW aatams_sattag_qc_data_summary_view AS
+SELECT v.data_type,
+       v.species_name,
+       v.sattag_program,
+       v.state_country AS release_site,
+       count(DISTINCT v.tag_code) AS no_animals,
+       sum(v.nb_profiles) AS total_nb_profiles,
+       sum(v.nb_measurements) AS total_nb_measurements,
+       min(v.coverage_start) AS coverage_start,
+       max(v.coverage_end) AS coverage_end,
+       round(avg(v.coverage_duration), 1) AS mean_coverage_duration,
+       round(min(v.coverage_duration), 1) || ' - ' || round(max(v.coverage_duration), 1) AS no_data_days, -- Range in number of data days
+ v.tag_type,
+ min(v.min_lat) AS min_lat,
+ max(v.max_lat) AS max_lat,
+ min(v.min_lon) AS min_lon,
+ max(v.max_lon) AS max_lon,
+ min(v.min_depth) AS min_depth,
+ max(v.max_depth) AS max_depth
+FROM aatams_sattag_qc_all_deployments_view v
+GROUP BY v.data_type,
+         v.sattag_program,
+         v.state_country,
+         v.species_name,
+         v.tag_type
+HAVING sum(v.nb_profiles) != 0
+ORDER BY v.data_type,
+         v.species_name,
+         v.tag_type,
+         min(v.coverage_start);
+
+grant all on table aatams_sattag_qc_data_summary_view to public;

--- a/report/SQL_reporting_queries/asset_map.sql
+++ b/report/SQL_reporting_queries/asset_map.sql
@@ -13,6 +13,15 @@ WITH soop_cpr AS (
   FROM soop_auscpr.soop_auscpr_pci_trajectory_map 
     WHERE vessel_name != 'RV Cape Ferguson' AND vessel_name != 'RV Solander'
 	GROUP BY vessel_name),
+  aatams_sattag_qc_dm AS (
+  SELECT device_id,
+	min(timestamp) AS date_start,
+	max(timestamp) AS date_end,
+	ST_CENTROID(ST_COLLECT(geom)) AS geom
+  FROM aatams_sattag_qc_dm.aatams_sattag_qc_profile_map
+	GROUP BY device_id 
+	ORDER BY random()
+	LIMIT 35),
   aatams_sattag_dm AS (
   SELECT device_id,
 	min(timestamp) AS date_start,
@@ -20,6 +29,15 @@ WITH soop_cpr AS (
 	ST_CENTROID(ST_COLLECT(geom)) AS geom
   FROM aatams_sattag_dm.aatams_sattag_dm_profile_map
 	GROUP BY device_id 
+	ORDER BY random()
+	LIMIT 35),
+  aatams_sattag_qc_nrt AS (
+  SELECT device_id,
+	min(timestamp) AS date_start,
+	max(timestamp) AS date_end,
+	ST_CENTROID(ST_COLLECT(geom)) AS geom
+  FROM aatams_sattag_qc_nrt.aatams_sattag_qc_profile_map
+	GROUP BY device_id
 	ORDER BY random()
 	LIMIT 35),
   aatams_sattag_nrt AS (
@@ -787,7 +805,38 @@ UNION ALL
 	'Point' AS gtype,
 	'#15D659' AS colour
   FROM aatams_snowpetrel
-  
+ 
+-- New SATTAG QC DM 
+  UNION ALL
+
+  SELECT 'Animal Tracking' AS facility,
+	'Biologging New Quality Control' AS subfacility,
+	'delayed-mode' AS product,
+	device_id AS platform_code,
+	'Seals and sea lions' AS platform_type,
+	date_start,
+	date_end,
+	TRUE AS w_temp_b,
+	TRUE AS w_psal_b,
+	FALSE AS w_oxygen_b,
+	FALSE AS w_co2_b,
+	TRUE AS w_chlorophyll_b,
+	FALSE AS turb_b,
+	FALSE AS w_current_b,
+	FALSE AS wave_b,
+	FALSE AS air_temperature_b,
+	FALSE AS air_pressure_b,
+	FALSE AS air_co2_b,
+	FALSE AS wind_b,
+	FALSE AS plankton_b,
+	FALSE AS optical_properties_b,
+	TRUE AS animal_location_b,
+	geom,
+	'Point' AS gtype,
+	'#15D659' AS colour
+  FROM aatams_sattag_qc_dm
+	WHERE st_x(geom) > 0
+ 
 UNION ALL
 
   SELECT 'Animal Tracking' AS facility,
@@ -847,7 +896,38 @@ UNION ALL
 	'#15D659' AS colour
   FROM aatams_sattag_nrt
 	WHERE st_x(geom) > 0
-	
+
+-- New SATTAG QC NRT 
+UNION ALL
+
+  SELECT 'Animal Tracking' AS facility,
+	'Biologging New Quality Control' AS subfacility,
+	'real-time' AS product,
+	device_id AS platform_code,
+	'Seals and sea lions' AS platform_type,
+	date_start,
+	date_end,
+	TRUE AS w_temp_b,
+	TRUE AS w_psal_b,
+	FALSE AS w_oxygen_b,
+	FALSE AS w_co2_b,
+	FALSE AS w_chlorophyll_b,
+	FALSE AS turb_b,
+	FALSE AS w_current_b,
+	FALSE AS wave_b,
+	FALSE AS air_temperature_b,
+	FALSE AS air_pressure_b,
+	FALSE AS air_co2_b,
+	FALSE AS wind_b,
+	FALSE AS plankton_b,
+	FALSE AS optical_properties_b,
+	TRUE AS animal_location_b,
+	geom,
+	'Point' AS gtype,
+	'#15D659' AS colour
+  FROM aatams_sattag_qc_nrt
+	WHERE st_x(geom) > 0
+
 ---- Deep Water Moorings-TS
 UNION ALL
 

--- a/report/SQL_reporting_queries/summary_totals.sql
+++ b/report/SQL_reporting_queries/summary_totals.sql
@@ -118,7 +118,19 @@ WITH argo AS (
 	t.t AS stat_3_value 
   FROM aatams_acoustic_registered_totals_view,t 
 	WHERE no_times_detected = 'Total'),
-	
+
+-- New SATTAG QC
+  aatams_sattag_qc AS (
+  SELECT 'Animal tracking (satellite) New Quality Control'::text AS facility, 
+	'# animals equipped with satellite tags'::text AS stat_1_attrib, 
+	no_deployments AS stat_1_value,
+	'# profiles'::text AS stat_2_attrib, 
+	no_data AS stat_2_value, 
+	'# measurements'::text AS stat_3_attrib, 
+	no_data2 AS stat_3_value 
+  FROM totals_view 
+	WHERE facility = 'AATAMS'::text AND subfacility = 'Biologging'::text AND type = 'TOTAL'),
+
   aatams_sattag AS (
   SELECT 'Animal tracking (satellite)'::text AS facility, 
 	'# animals equipped with satellite tags'::text AS stat_1_attrib, 
@@ -170,6 +182,8 @@ WITH argo AS (
   SELECT * FROM acorn
   UNION ALL
   SELECT * FROM aatams_acoustic
+  UNION ALL
+  SELECT * FROM aatams_sattag_qc
   UNION ALL
   SELECT * FROM aatams_sattag
   UNION ALL

--- a/report/SQL_reporting_queries/totals.sql
+++ b/report/SQL_reporting_queries/totals.sql
@@ -134,6 +134,46 @@ UNION ALL
 	COALESCE(min(min_depth)||' - '||max(max_depth)) AS depth_range
   FROM aatams_sattag_all_deployments_view
 
+-- AATAMS - new DM products
+UNION ALL
+
+  SELECT 'AATAMS' AS facility,
+	'Biologging' AS subfacility,
+	data_type AS type,
+	COUNT(DISTINCT(sattag_program)) AS no_projects,
+	COUNT(DISTINCT(species_name)) AS no_platforms,
+	COUNT(DISTINCT(tag_type)) AS no_instruments,
+	SUM(no_animals) AS no_deployments,
+	SUM(total_nb_profiles) AS no_data,
+	SUM(total_nb_measurements) AS no_data2,
+	NULL::numeric AS no_data3,
+	NULL::numeric AS no_data4,
+	COALESCE(to_char(min(coverage_start),'DD/MM/YYYY')||' - '||to_char(max(coverage_end),'DD/MM/YYYY')) AS temporal_range,
+	COALESCE(min(min_lat)||' - '||max(max_lat)) AS lat_range,
+	COALESCE(min(min_lon)||' - '||max(max_lon)) AS lon_range,
+	COALESCE(min(min_depth)||' - '||max(max_depth)) AS depth_range
+  FROM aatams_sattag_qc_data_summary_view
+	GROUP BY data_type
+
+UNION ALL
+
+  SELECT 'AATAMS' AS facility,
+	'Biologging New Quality Control' AS subfacility,
+	'TOTAL' AS type,
+	COUNT(DISTINCT(sattag_program)) AS no_projects,
+	COUNT(DISTINCT(species_name)) AS no_platforms,
+	COUNT(DISTINCT(tag_type)) AS no_instruments,
+	COUNT(DISTINCT(tag_code)) AS no_deployments,
+	SUM(nb_profiles) AS no_data,
+	SUM(nb_measurements) AS no_data2,
+	NULL::numeric AS no_data3,
+	NULL::numeric AS no_data4,
+	COALESCE(to_char(min(coverage_start),'DD/MM/YYYY')||' - '||to_char(max(coverage_end),'DD/MM/YYYY')) AS temporal_range,
+	COALESCE(min(min_lat)||' - '||max(max_lat)) AS lat_range,
+	COALESCE(min(min_lon)||' - '||max(max_lon)) AS lon_range,
+	COALESCE(min(min_depth)||' - '||max(max_depth)) AS depth_range
+  FROM aatams_sattag_qc_all_deployments_view
+
 -- AATAMS - Biologging
 UNION ALL  
 

--- a/report/reporting_script.sh
+++ b/report/reporting_script.sh
@@ -19,6 +19,8 @@ echo @@@@@@@@ Reporting view - AATAMS Biologging @@@@@@@@
 psql -h $HOST -U $USER -d harvest < SQL_reporting_queries/aatams_biologging.sql;
 echo @@@@@@@@ Reporting view - AATAMS Satellite tagging @@@@@@@@
 psql -h $HOST -U $USER -d harvest < SQL_reporting_queries/aatams_sattag.sql;
+echo @@@@@@@@ Reporting view - AATAMS Satellite tagging Quality Control Tables @@@@@@@@
+psql -h $HOST -U $USER -d harvest < SQL_reporting_queries/aatams_sattag_qc.sql;
 echo @@@@@@@@ Reporting views - ABOS @@@@@@@@
 psql -h $HOST -U $USER -d harvest < SQL_reporting_queries/abos.sql;
 echo @@@@@@@@ Reporting views - ACORN @@@@@@@@


### PR DESCRIPTION
This implements the new queries for the SATTAG QC datasets. To avoid clashing/duplicate statistics, I rename the new SATTAG QC datasets at sub facility-level - codename "New Quality Control". 

What was tested:

- [x] intermediate views to compute totals
- [x] Totals and summaries
- [x] Asset_maps


@evacougnon, worth checking if table names will be kept as it is now at RC!

PS: This is only mergeable when the new tables ```aatams_sattag_qc_[dm/nrt]``` are online in prod.